### PR TITLE
Fix #57: User.Name not being populated on timeentry list

### DIFF
--- a/harvest/estimate_test.go
+++ b/harvest/estimate_test.go
@@ -82,7 +82,8 @@ func TestEstimateService_List(t *testing.T) {
 				},
 				LineItems: &lineItemsOne,
 				Creator: &harvest.User{
-					ID: harvest.Int64(1782884),
+					ID:   harvest.Int64(1782884),
+					Name: harvest.String("Bob Powell"),
 				},
 				ClientKey:      harvest.String("13dc088aa7d51ec687f186b146730c3c75dc7423"),
 				Number:         harvest.String("1001"),
@@ -112,7 +113,8 @@ func TestEstimateService_List(t *testing.T) {
 				},
 				LineItems: &lineItemsTwo,
 				Creator: &harvest.User{
-					ID: harvest.Int64(1782884),
+					ID:   harvest.Int64(1782884),
+					Name: harvest.String("Bob Powell"),
 				},
 				ClientKey:      harvest.String("a5ffaeb30c55776270fcd3992b70332d769f97e7"),
 				Number:         harvest.String("1000"),
@@ -200,7 +202,8 @@ func TestEstimateService_Get(t *testing.T) {
 		},
 		LineItems: &lineItemsOne,
 		Creator: &harvest.User{
-			ID: harvest.Int64(1782884),
+			ID:   harvest.Int64(1782884),
+			Name: harvest.String("Bob Powell"),
 		},
 		ClientKey:      harvest.String("13dc088aa7d51ec687f186b146730c3c75dc7423"),
 		Number:         harvest.String("1001"),

--- a/harvest/invoice_test.go
+++ b/harvest/invoice_test.go
@@ -97,7 +97,8 @@ func TestInvoiceService_CreateInvoice(t *testing.T) {
 					},
 					LineItems: &lineItems,
 					Creator: &harvest.User{
-						ID: harvest.Int64(1782884),
+						ID:   harvest.Int64(1782884),
+						Name: harvest.String("Bob Powell"),
 					},
 					ClientKey:      harvest.String("8b86437630b6c260c1bfa289f0154960f83b606d"),
 					Number:         harvest.String("1002"),
@@ -218,7 +219,8 @@ func TestInvoiceService_CreateInvoice(t *testing.T) {
 					},
 					LineItems: &lineItems,
 					Creator: &harvest.User{
-						ID: harvest.Int64(1782884),
+						ID:   harvest.Int64(1782884),
+						Name: harvest.String("Bob Powell"),
 					},
 					ClientKey:      harvest.String("16173155e0a01542b8c7f689888cb3eaeda0dc94"),
 					Number:         harvest.String("1002"),
@@ -422,7 +424,8 @@ func TestInvoiceService_GetInvoice(t *testing.T) {
 					},
 					LineItems: &lineItems,
 					Creator: &harvest.User{
-						ID: harvest.Int64(1782884),
+						ID:   harvest.Int64(1782884),
+						Name: harvest.String("Bob Powell"),
 					},
 					ClientKey:      harvest.String("9e97f4a65c5b83b1fc02f54e5a41c9dc7d458542"),
 					Number:         harvest.String("1000"),
@@ -613,7 +616,8 @@ func TestInvoiceService_ListInvoices(t *testing.T) {
 							},
 							LineItems: &lineItemsOne,
 							Creator: &harvest.User{
-								ID: harvest.Int64(1782884),
+								ID:   harvest.Int64(1782884),
+								Name: harvest.String("Bob Powell"),
 							},
 							ClientKey:      harvest.String("21312da13d457947a217da6775477afee8c2eba8"),
 							Number:         harvest.String("1001"),
@@ -656,7 +660,8 @@ func TestInvoiceService_ListInvoices(t *testing.T) {
 							},
 							LineItems: &lineItemsTwo,
 							Creator: &harvest.User{
-								ID: harvest.Int64(1782884),
+								ID:   harvest.Int64(1782884),
+								Name: harvest.String("Bob Powell"),
 							},
 							ClientKey:      harvest.String("9e97f4a65c5b83b1fc02f54e5a41c9dc7d458542"),
 							Number:         harvest.String("1000"),
@@ -810,7 +815,8 @@ func TestInvoiceService_UpdateInvoice(t *testing.T) {
 					PurchaseOrder: harvest.String("2345"),
 					LineItems:     &lineItems,
 					Creator: &harvest.User{
-						ID: harvest.Int64(1782884),
+						ID:   harvest.Int64(1782884),
+						Name: harvest.String("Bob Powell"),
 					},
 					ClientKey:      harvest.String("8b86437630b6c260c1bfa289f0154960f83b606d"),
 					Number:         harvest.String("1002"),

--- a/harvest/time_entry_test.go
+++ b/harvest/time_entry_test.go
@@ -203,7 +203,8 @@ func TestTimesheetService_ListTimeEntries(t *testing.T) {
 				SpentDate: harvest.DateP(harvest.Date{time.Date(
 					2017, 3, 2, 0, 0, 0, 0, time.Local)}),
 				User: &harvest.User{
-					ID: harvest.Int64(1782959),
+					ID:   harvest.Int64(1782959),
+					Name: harvest.String("Kim Allen"),
 				},
 				Client: &harvest.Client{
 					ID:   harvest.Int64(5735774),
@@ -261,7 +262,8 @@ func TestTimesheetService_ListTimeEntries(t *testing.T) {
 				SpentDate: harvest.DateP(harvest.Date{time.Date(
 					2017, 3, 1, 0, 0, 0, 0, time.Local)}),
 				User: &harvest.User{
-					ID: harvest.Int64(1782959),
+					ID:   harvest.Int64(1782959),
+					Name: harvest.String("Kim Allen"),
 				},
 				Client: &harvest.Client{
 					ID:   harvest.Int64(5735776),
@@ -317,7 +319,8 @@ func TestTimesheetService_ListTimeEntries(t *testing.T) {
 				SpentDate: harvest.DateP(harvest.Date{time.Date(
 					2017, 3, 1, 0, 0, 0, 0, time.Local)}),
 				User: &harvest.User{
-					ID: harvest.Int64(1782959),
+					ID:   harvest.Int64(1782959),
+					Name: harvest.String("Kim Allen"),
 				},
 				Client: &harvest.Client{
 					ID:   harvest.Int64(5735776),
@@ -371,7 +374,8 @@ func TestTimesheetService_ListTimeEntries(t *testing.T) {
 				SpentDate: harvest.DateP(harvest.Date{time.Date(
 					2017, 3, 1, 0, 0, 0, 0, time.Local)}),
 				User: &harvest.User{
-					ID: harvest.Int64(1782959),
+					ID:   harvest.Int64(1782959),
+					Name: harvest.String("Kim Allen"),
 				},
 				Client: &harvest.Client{
 					ID:   harvest.Int64(5735776),
@@ -479,7 +483,8 @@ func TestTimesheetService_RestartTimeEntry(t *testing.T) {
 		ID:        harvest.Int64(662202797),
 		SpentDate: harvest.DateP(harvest.Date{spentDate}),
 		User: &harvest.User{
-			ID: harvest.Int64(1795925),
+			ID:   harvest.Int64(1795925),
+			Name: harvest.String("Jane Smith"),
 		},
 		Client: &harvest.Client{
 			ID:   harvest.Int64(5735776),
@@ -565,7 +570,8 @@ func TestTimesheetService_StopTimeEntry(t *testing.T) {
 		ID:        harvest.Int64(662202797),
 		SpentDate: harvest.DateP(harvest.Date{spentDate}),
 		User: &harvest.User{
-			ID: harvest.Int64(1795925),
+			ID:   harvest.Int64(1795925),
+			Name: harvest.String("Jane Smith"),
 		},
 		Client: &harvest.Client{
 			ID:   harvest.Int64(5735776),
@@ -668,7 +674,8 @@ func TestTimesheetService_UpdateTimeEntry(t *testing.T) {
 		UpdatedAt: &updatedTimeEntry,
 		SpentDate: harvest.DateP(harvest.Date{spentDate}),
 		User: &harvest.User{
-			ID: harvest.Int64(1782959),
+			ID:   harvest.Int64(1782959),
+			Name: harvest.String("Kim Allen"),
 		},
 		Client: &harvest.Client{
 			ID:   harvest.Int64(5735774),

--- a/harvest/user.go
+++ b/harvest/user.go
@@ -20,6 +20,8 @@ type User struct {
 	FirstName *string `json:"first_name,omitempty"`
 	// The last name of the user.
 	LastName *string `json:"last_name,omitempty"`
+	// The full name of the user - this is populated when listing time entries
+	Name *string `json:"name,omitempty"`
 	// The email address of the user.
 	Email *string `json:"email,omitempty"`
 	// The telephone number for the user.


### PR DESCRIPTION
The `Name` field of the `User` object may sometimes be used by Harvest to populate the full name. The `User` structure needs to be aware of this and optionally populate this on a JSON decode if the `User` field is present.